### PR TITLE
Fix build error

### DIFF
--- a/src/utils/genius-lyrics-api.d.ts
+++ b/src/utils/genius-lyrics-api.d.ts
@@ -1,39 +1,34 @@
-declare module "genius-lyrics-api" {
-  interface SearchOptions {
-    apiKey: string;
-    title: string;
-    artist?: string;
-    optimizeQuery?: boolean;
-  }
-
-  interface Song {
-    id: number;
-    title: string;
-    url: string;
-  }
-
-  interface LyricsOptions {
-    title: string;
-    artist: string;
-  }
-
-  interface AlbumArtOptions {
-    title: string;
-    artist: string;
-  }
-
-  interface SongByIdOptions {
-    id: number;
-    apiKey: string;
-  }
-
-  export function search(options: SearchOptions): Promise<Song[]>;
-  export function getSong(options: {
-    id: number;
-    apiKey: string;
-  }): Promise<Song>;
-  export function getLyrics(options: LyricsOptions): Promise<string>;
-  export function getAlbumArt(options: AlbumArtOptions): Promise<string>;
-  export function getSongById(options: SongByIdOptions): Promise<Song>;
-  export function searchSong(options: SearchOptions): Promise<Song[]>;
+module "genius-lyrics-api" {
+ interface SearchOptions {
+   apiKey: string;
+   title: string;
+   artist?: string;
+   optimizeQuery?: boolean;
+ }
+ interface Song {
+   id: number;
+   title: string;
+   url: string;
+ }
+ interface LyricsOptions {
+   title: string;
+   artist: string;
+ }
+ interface AlbumArtOptions {
+   title: string;
+   artist: string;
+ }
+ interface SongByIdOptions {
+   id: number;
+   apiKey: string;
+ }
+ export function search(options: SearchOptions): Promise<Song[]>;
+ export function getSong(options: {
+   id: number;
+   apiKey: string;
+ }): Promise<Song>;
+ export function getLyrics(options: LyricsOptions): Promise<string>;
+ export function getAlbumArt(options: AlbumArtOptions): Promise<string>;
+ export function getSongById(options: SongByIdOptions): Promise<Song>;
+ export function searchSong(options: SearchOptions): Promise<Song[]>;
 }


### PR DESCRIPTION
```v24.3.0
:/home/container$ npm run build
> lavamusic@5.0.0-beta build
> tsup
CLI Building entry: src/LavaClient.ts, src/config.ts, src/env.ts, src/index.ts, src/shard.ts, src/types.ts, src/database/server.ts, src/plugin/index.ts, src/commands/config/247.ts, src/commands/config/Dj.ts, src/commands/config/Language.ts, src/commands/config/Prefix.ts, src/commands/config/Setup.ts, src/commands/filters/8d.ts, src/commands/filters/BassBoost.ts, src/commands/filters/Karaoke.ts, src/commands/filters/LowPass.ts, src/commands/filters/NightCore.ts, src/commands/filters/Pitch.ts, src/commands/filters/Rate.ts, src/commands/filters/Reset.ts, src/commands/filters/Rotation.ts, src/commands/filters/Speed.ts, src/commands/filters/Tremolo.ts, src/commands/filters/Vibrato.ts, src/commands/info/About.ts, src/commands/info/Botinfo.ts, src/commands/info/Help.ts, src/commands/info/Invite.ts, src/commands/info/LavaLink.ts, src/commands/info/Ping.ts, src/structures/Command.ts, src/structures/Context.ts, src/structures/Event.ts, src/structures/I18n.ts, src/structures/LavalinkClient.ts, src/structures/Lavamusic.ts, src/structures/Logger.ts, src/structures/index.ts, src/commands/music/Autoplay.ts, src/commands/music/ClearQueue.ts, src/commands/music/FairPlay.ts, src/commands/music/Grab.ts, src/commands/music/Join.ts, src/commands/music/Leave.ts, src/commands/music/Loop.ts, src/commands/music/Lyrics.ts, src/commands/music/Nowplaying.ts, src/commands/music/Pause.ts, src/commands/music/Play.ts, src/commands/music/PlayLocal.ts, src/commands/music/PlayNext.ts, src/commands/music/Queue.ts, src/commands/music/Remove.ts, src/commands/music/Replay.ts, src/commands/music/Resume.ts, src/commands/music/Search.ts, src/commands/music/Seek.ts, src/commands/music/Shuffle.ts, src/commands/music/Skip.ts, src/commands/music/Skipto.ts, src/commands/music/Stop.ts, src/commands/music/Volume.ts, src/utils/BotLog.ts, src/utils/Buttons.ts, src/utils/SetupSystem.ts, src/utils/ThemeSelector.ts, src/utils/Utils.ts, src/utils/genius-lyrics-api.d.ts, src/commands/playlist/AddSong.ts, src/commands/playlist/Create.ts, src/commands/playlist/Delete.ts, src/commands/playlist/List.ts, src/commands/playlist/Load.ts, src/commands/playlist/RemoveSong.ts, src/commands/playlist/Steal.ts, src/commands/dev/CreateInvite.ts, src/commands/dev/DeleteInvites.ts, src/commands/dev/Deploy.ts, src/commands/dev/Eval.ts, src/commands/dev/GuildLeave.ts, src/commands/dev/GuildList.ts, src/commands/dev/Restart.ts, src/commands/dev/Shutdown.ts, src/events/client/ChannelDelete.ts, src/events/client/GuildCreate.ts, src/events/client/GuildDelete.ts, src/events/client/InteractionCreate.ts, src/events/client/MessageCreate.ts, src/events/client/Raw.ts, src/events/client/Ready.ts, src/events/client/SetupButtons.ts, src/events/client/SetupSystem.ts, src/events/client/VoiceStateUpdate.ts, src/events/node/Connect.ts, src/events/node/Destroy.ts, src/events/player/PlayerDestroy.ts, src/events/player/PlayerDisconnect.ts, src/events/player/PlayerMuteChange.ts, src/events/player/PlayerPaused.ts, src/events/player/PlayerResumed.ts, src/events/player/QueueEnd.ts, src/events/player/TrackEnd.ts, src/events/player/TrackStart.ts, src/plugin/plugins/antiCrash.ts, src/plugin/plugins/keepAlive.ts, src/plugin/plugins/updateStatus.ts, src/utils/functions/player.ts CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.0
CLI Using tsup config: /home/container/tsup.config.ts CLI Target: esnext
CLI Cleaning output folder
CJS Build start
✘ [ERROR]   × `declare` modifier not allowed for code already in an ambient context
   ╭─[/home/container/src/utils/genius-lyrics-api.d.ts:1:1]
 1 │ declare module "genius-lyrics-api" {
   · ───────
 2 │   interface SearchOptions {
 3 │     apiKey: string;
 4 │     title: string;
   ╰────
Caused by:
    Syntax Error [plugin swc]
  This error came from the "onLoad" callback registered here:
    node_modules/tsup/dist/index.js:349:13:
      349 │       build2.onLoad({ filter: /\.[jt]sx?$/ }, async (args) => {
          ╵              ~~~~~~
    at setup (/home/container/node_modules/tsup/dist/index.js:349:14)
    at handlePlugins (/home/container/node_modules/esbuild/lib/main.js:1139:21)
    at buildOrContextImpl (/home/container/node_modules/esbuild/lib/main.js:852:5)
    at Object.buildOrContext (/home/container/node_modules/esbuild/lib/main.js:678:5)
    at /home/container/node_modules/esbuild/lib/main.js:2024:15
    at new Promise (<anonymous>)
    at Object.build (/home/container/node_modules/esbuild/lib/main.js:2023:25)
    at build (/home/container/node_modules/esbuild/lib/main.js:1874:51)
    at runEsbuild (/home/container/node_modules/tsup/dist/index.js:525:35)
CJS Build failed
Error: Build failed with 1 error:
error:   × `declare` modifier not allowed for code already in an ambient context
   ╭─[/home/container/src/utils/genius-lyrics-api.d.ts:1:1]
 1 │ declare module "genius-lyrics-api" {
   · ───────
 2 │   interface SearchOptions {
 3 │     apiKey: string;
 4 │     title: string;
   ╰────
Caused by:
    Syntax Error
    at failureErrorWithLog (/home/container/node_modules/esbuild/lib/main.js:1465:15)
    at /home/container/node_modules/esbuild/lib/main.js:924:25
    at runOnEndCallbacks (/home/container/node_modules/esbuild/lib/main.js:1305:45)
    at buildResponseToResult (/home/container/node_modules/esbuild/lib/main.js:922:7)
    at /home/container/node_modules/esbuild/lib/main.js:949:16
    at responseCallbacks.<computed> (/home/container/node_modules/esbuild/lib/main.js:601:9)
    at handleIncomingPacket (/home/container/node_modules/esbuild/lib/main.js:656:12)
    at Socket.readFromStdout (/home/container/node_modules/esbuild/lib/main.js:579:7)
    at Socket.emit (node:events:507:28)
    at addChunk (node:internal/streams/readable:559:12)```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal module declaration updated with no impact on user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->