### PR TITLE
Fix: Support multi-word node names in movenode command

### DIFF
--- a/src/commands/dev/MoveNode.ts
+++ b/src/commands/dev/MoveNode.ts
@@ -48,7 +48,7 @@ export default class MoveNode extends Command {
     args: string[],
   ): Promise<any> {
     // If no node specified, show available nodes as before
-    const nodeId = args[0] || ctx.args?.[0];
+    const nodeId = args.length > 0 ? args.join(" ") : ctx.args?.join(" ");
     const allPlayers = client.manager.players;
     const currentNodeId =
       allPlayers.size > 0


### PR DESCRIPTION
BEFORE:
<img width="514" height="152" alt="Zrzut ekranu 2025-08-01 000914" src="https://github.com/user-attachments/assets/7444147b-a830-4b3f-88ef-d243fc180b28" />

AFTER:
<img width="503" height="477" alt="image" src="https://github.com/user-attachments/assets/f1dded24-e740-4453-abd7-6213a541b673" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of node identifiers to support multi-word inputs when executing commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->