### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
 	},
 	"homepage": "https://github.com/appujet/lavamusic#readme",
 	"devDependencies": {
-		"@biomejs/biome": "2.2.0",
-		"@swc/core": "^1.13.4",
+		"@biomejs/biome": "2.2.2",
+		"@swc/core": "^1.13.5",
 		"@types/i18n": "^0.13.12",
 		"@types/node": "^24.3.0",
 		"@types/signale": "^1.4.7",
@@ -49,13 +49,13 @@
 		"discord.js": "^14.22.1",
 		"genius-lyrics-api": "^3.2.1",
 		"i18n": "^0.15.1",
-		"lavalink-client": "https://pkg.pr.new/Tomato6966/lavalink-client@136",
+		"lavalink-client": "^2.6.0",
 		"node-system-stats": "^2.0.5",
 		"signale": "^1.4.0",
 		"topgg-autoposter": "^2.0.2",
 		"tslib": "^2.8.1",
-		"undici": "^7.14.0",
-		"zod": "^4.0.17"
+		"undici": "^7.15.0",
+		"zod": "^4.1.1"
 	},
 	"signale": {
 		"displayScope": true,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@dotenvx/dotenvx": "^1.49.0",
 		"@prisma/client": "^6.14.0",
 		"@top-gg/sdk": "^3.1.6",
-		"discord.js": "^14.22.0",
+		"discord.js": "^14.22.1",
 		"genius-lyrics-api": "^3.2.1",
 		"i18n": "^0.15.1",
 		"lavalink-client": "https://pkg.pr.new/Tomato6966/lavalink-client@136",

--- a/package.json
+++ b/package.json
@@ -33,20 +33,20 @@
 	},
 	"homepage": "https://github.com/appujet/lavamusic#readme",
 	"devDependencies": {
-		"@biomejs/biome": "2.1.3",
-		"@swc/core": "^1.13.3",
+		"@biomejs/biome": "2.2.0",
+		"@swc/core": "^1.13.4",
 		"@types/i18n": "^0.13.12",
-		"@types/node": "^24.1.0",
+		"@types/node": "^24.3.0",
 		"@types/signale": "^1.4.7",
-		"prisma": "^6.13.0",
+		"prisma": "^6.14.0",
 		"tsup": "^8.5.0",
 		"typescript": "^5.9.2"
 	},
 	"dependencies": {
-		"@dotenvx/dotenvx": "^1.48.4",
-		"@prisma/client": "^6.13.0",
+		"@dotenvx/dotenvx": "^1.49.0",
+		"@prisma/client": "^6.14.0",
 		"@top-gg/sdk": "^3.1.6",
-		"discord.js": "^14.21.0",
+		"discord.js": "^14.22.0",
 		"genius-lyrics-api": "^3.2.1",
 		"i18n": "^0.15.1",
 		"lavalink-client": "https://pkg.pr.new/Tomato6966/lavalink-client@136",
@@ -54,8 +54,8 @@
 		"signale": "^1.4.0",
 		"topgg-autoposter": "^2.0.2",
 		"tslib": "^2.8.1",
-		"undici": "^7.13.0",
-		"zod": "^4.0.14"
+		"undici": "^7.14.0",
+		"zod": "^4.0.17"
 	},
 	"signale": {
 		"displayScope": true,

--- a/src/events/client/Ready.ts
+++ b/src/events/client/Ready.ts
@@ -1,11 +1,12 @@
 import { AutoPoster } from "topgg-autoposter";
 import { env } from "../../env";
 import { Event, type Lavamusic } from "../../structures/index";
+import { Events } from "discord.js";
 
 export default class Ready extends Event {
 	constructor(client: Lavamusic, file: string) {
 		super(client, file, {
-			name: "clientReady",
+			name: Events.ClientReady,
 		});
 	}
 

--- a/src/events/client/Ready.ts
+++ b/src/events/client/Ready.ts
@@ -5,7 +5,7 @@ import { Event, type Lavamusic } from "../../structures/index";
 export default class Ready extends Event {
 	constructor(client: Lavamusic, file: string) {
 		super(client, file, {
-			name: "ready",
+			name: "clientReady",
 		});
 	}
 

--- a/src/plugin/plugins/updateStatus.ts
+++ b/src/plugin/plugins/updateStatus.ts
@@ -6,7 +6,7 @@ const updateStatusPlugin: BotPlugin = {
 	version: "1.0.0",
 	author: "Appu",
 	initialize: (client: Lavamusic) => {
-		client.on("ready", () => client.utils.updateStatus(client));
+		client.on("clientReady", () => client.utils.updateStatus(client));
 	},
 };
 

--- a/src/plugin/plugins/updateStatus.ts
+++ b/src/plugin/plugins/updateStatus.ts
@@ -1,12 +1,13 @@
 import type { Lavamusic } from "../../structures/index";
 import type { BotPlugin } from "../index";
+import { Events } from "discord.js";
 
 const updateStatusPlugin: BotPlugin = {
 	name: "Update Status Plugin",
 	version: "1.0.0",
 	author: "Appu",
 	initialize: (client: Lavamusic) => {
-		client.on("clientReady", () => client.utils.updateStatus(client));
+		client.on(Events.ClientReady, () => client.utils.updateStatus(client));
 	},
 };
 

--- a/src/shard.ts
+++ b/src/shard.ts
@@ -1,4 +1,4 @@
-import { ShardingManager } from "discord.js";
+import { Events, ShardingManager } from "discord.js";
 import { env } from "./env";
 import type Logger from "./structures/Logger";
 
@@ -11,7 +11,7 @@ export async function shardStart(logger: Logger) {
 	});
 
 	manager.on("shardCreate", (shard) => {
-		shard.on("clientReady", () => {
+		shard.on(Events.ClientReady, () => {
 			logger.start(
 				`[CLIENT] Shard ${shard.id} connected to Discord's Gateway.`,
 			);

--- a/src/shard.ts
+++ b/src/shard.ts
@@ -1,4 +1,4 @@
-import { Events, ShardingManager } from "discord.js";
+import { ShardingManager } from "discord.js";
 import { env } from "./env";
 import type Logger from "./structures/Logger";
 
@@ -11,7 +11,7 @@ export async function shardStart(logger: Logger) {
 	});
 
 	manager.on("shardCreate", (shard) => {
-		shard.on(Events.ClientReady, () => {
+		shard.on("ready", () => {
 			logger.start(
 				`[CLIENT] Shard ${shard.id} connected to Discord's Gateway.`,
 			);

--- a/src/shard.ts
+++ b/src/shard.ts
@@ -11,7 +11,7 @@ export async function shardStart(logger: Logger) {
 	});
 
 	manager.on("shardCreate", (shard) => {
-		shard.on("ready", () => {
+		shard.on("clientReady", () => {
 			logger.start(
 				`[CLIENT] Shard ${shard.id} connected to Discord's Gateway.`,
 			);


### PR DESCRIPTION
`(node:51) DeprecationWarning: The ready event has been renamed to clientReady to distinguish it from the gateway READY event and will only emit under that name in v15. Please use clientReady instead.
(Use `node --trace-deprecation ...` to show where the warning was created)`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved readiness handling so status updates and shard logs occur at the correct lifecycle moment for more consistent startup behavior.

* **Chores**
  * Bumped several dependencies to newer minor/patch versions for improved stability and compatibility; no configuration or functional changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->